### PR TITLE
Fix compilation issue with pcl_recorder not finding tf2_eigen.h in RO…

### DIFF
--- a/pcl_recorder/include/PclRecorderROS2.h
+++ b/pcl_recorder/include/PclRecorderROS2.h
@@ -10,7 +10,15 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
+
+#ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
+
+
+
 #include <rclcpp/time_source.hpp>
 
 class PclRecorderROS2 : public rclcpp::Node

--- a/pcl_recorder/package.xml
+++ b/pcl_recorder/package.xml
@@ -24,6 +24,7 @@
 
   <build_depend>pcl_conversions</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>tf2_eigen</build_depend>
   <build_export_depend>pcl_conversions</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <exec_depend>pcl_conversions</exec_depend>


### PR DESCRIPTION
 
 "Fix compilation issue with pcl_recorder not finding tf2_eigen.h in ROS Humble version
 
 ```bash
 fatal error: tf2_eigen/tf2_eigen.h: No such file or directory
     | #include <tf2_eigen/tf2_eigen.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```